### PR TITLE
Python support async functions

### DIFF
--- a/src/languages/python/python.ts
+++ b/src/languages/python/python.ts
@@ -30,7 +30,7 @@ function getFunctionName(
   // FIXME: We should replace this with a proper parsing solution.
   // - https://github.com/autometrics-dev/vscode-autometrics/issues/29
   const functionRegex =
-    /^(?<indentation>\s*)(?async\s*)def\s*(?<name>[\dA-z]+)?\s*\(/;
+    /^(?<indentation>\s*)(async\s*)?def\s*(?<name>[\dA-z]+)?\s*\(/;
   const match = textLine.text.match(functionRegex);
   const name = match?.groups?.name;
   const indentation = match?.groups?.indentation ?? "";

--- a/src/languages/python/python.ts
+++ b/src/languages/python/python.ts
@@ -29,7 +29,8 @@ function getFunctionName(
   const textLine = document.lineAt(position.line);
   // FIXME: We should replace this with a proper parsing solution.
   // - https://github.com/autometrics-dev/vscode-autometrics/issues/29
-  const functionRegex = /^(?<indentation>\s*)def\s*(?<name>[\dA-z]+)?\s*\(/;
+  const functionRegex =
+    /^(?<indentation>\s*)(?async\s*)def\s*(?<name>[\dA-z]+)?\s*\(/;
   const match = textLine.text.match(functionRegex);
   const name = match?.groups?.name;
   const indentation = match?.groups?.indentation ?? "";

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -14,6 +14,14 @@ def div_unhandled(num1, num2):
   return result 
 `;
 
+const ASYNC_FUNC_CONTENT = `from autometrics.autometrics import autometrics
+
+@autometrics
+async def div_unhandled(num1, num2):
+  result = num1 / num2
+  return result 
+`;
+
 async function createTestDocument(content: string) {
   const document = await vscode.workspace.openTextDocument({
     language: "python",
@@ -40,6 +48,16 @@ suite("Extension Test Suite", () => {
 
     const line = 3;
     const character = 5;
+    const position = new vscode.Position(line, character);
+    const hover = PythonHover.provideHover(document, position);
+    assert.ok(hover);
+  });
+
+  test("should return hover content when hovering over an async function", async () => {
+    const document = await createTestDocument(ASYNC_FUNC_CONTENT);
+
+    const line = 3;
+    const character = 11;
     const position = new vscode.Position(line, character);
     const hover = PythonHover.provideHover(document, position);
     assert.ok(hover);


### PR DESCRIPTION
Fixes #32 

***

The regex that looks for python functions did not take into account the `async` keyword. This PR is a fix for that (with a test!)