### PR TITLE
Backport: Update ts plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.2.1
+
+- [chore] update TS plugin dependency to `v0.4.0`
+
 ## 0.2.0
 
 - [fix] add support for async functions in python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.2.0
+
+- [fix] add support for async functions in python
+
 ## 0.1.0
 
 - [chore] switch from yarn to npm

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Initial release which brings in basic Python support
 
 Update which brings TypeScript support using the TypeScript plugin `@autometrics/typescript-plugin`
 
+### 0.1.0
+
+Update to support tooltips over autometrics-decorated async python functions 
+
+
 ---
 
 ## Developing this extension

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Initial release which brings in basic Python support
 
 Update which brings TypeScript support using the TypeScript plugin `@autometrics/typescript-plugin`
 
-### 0.1.0
+### 0.2.0
 
 Update to support tooltips over autometrics-decorated async python functions 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "@autometrics/typescript-plugin": "^0.3.0",
+        "@autometrics/typescript-plugin": "^0.4.0",
         "typescript": "^4.9.5"
       },
       "devDependencies": {
@@ -29,9 +29,9 @@
       }
     },
     "node_modules/@autometrics/typescript-plugin": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@autometrics/typescript-plugin/-/typescript-plugin-0.3.0.tgz",
-      "integrity": "sha512-6BxYw8s8svEr4XwJk8l7prhZ5nK0L8vxtrr6sUOZ53umN/iYOoxXt3OQsZlKTSWwyYhGPQCH2wu68v98VYG3IQ=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@autometrics/typescript-plugin/-/typescript-plugin-0.4.0.tgz",
+      "integrity": "sha512-yfIm7Kh4kKA+FIccWxDG7gu6m9kQEqXw4fe74KFcekLz/DYHs26vAycnNOXAxKbXyun3np5PTQsPLjGoqNx1mg=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.17.16",
@@ -2866,9 +2866,9 @@
   },
   "dependencies": {
     "@autometrics/typescript-plugin": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@autometrics/typescript-plugin/-/typescript-plugin-0.3.0.tgz",
-      "integrity": "sha512-6BxYw8s8svEr4XwJk8l7prhZ5nK0L8vxtrr6sUOZ53umN/iYOoxXt3OQsZlKTSWwyYhGPQCH2wu68v98VYG3IQ=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@autometrics/typescript-plugin/-/typescript-plugin-0.4.0.tgz",
+      "integrity": "sha512-yfIm7Kh4kKA+FIccWxDG7gu6m9kQEqXw4fe74KFcekLz/DYHs26vAycnNOXAxKbXyun3np5PTQsPLjGoqNx1mg=="
     },
     "@esbuild/android-arm": {
       "version": "0.17.16",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "autometrics",
-  "version": "0.0.1",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "autometrics",
-      "version": "0.0.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@autometrics/typescript-plugin": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "displayName": "Autometrics",
   "license": "MIT",
   "description": "Show enhanced autometrics information from your code",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/autometrics-dev/vscode-autometrics"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "typescript": "^4.9.5",
-    "@autometrics/typescript-plugin": "^0.3.0"
+    "@autometrics/typescript-plugin": "^0.4.0"
   },
   "packageManager": "npm@9.6.2"
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "displayName": "Autometrics",
   "license": "MIT",
   "description": "Show enhanced autometrics information from your code",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/autometrics-dev/vscode-autometrics"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,7 +17,8 @@ function getFunctionName(
   position: vscode.Position,
 ): string | void {
   const textLine = document.lineAt(position.line);
-  const functionRegex = /^(?<indentation>\s*)def\s*(?<name>[\dA-z]+)?\s*\(/;
+  const functionRegex =
+    /^(?<indentation>\s*)(async\s*)?def\s*(?<name>[\dA-z]+)?\s*\(/;
   const match = textLine.text.match(functionRegex);
   const name = match?.groups?.name;
   const indentation = match?.groups?.indentation ?? "";

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -13,6 +13,14 @@ def div_unhandled(num1, num2):
   return result 
 `;
 
+const ASYNC_BASIC_CONTENT = `from autometrics.autometrics import autometrics
+
+@autometrics
+async def div_unhandled(num1, num2):
+  result = num1 / num2
+  return result 
+`;
+
 async function createTestDocument(content: string) {
   const document = await vscode.workspace.openTextDocument({
     language: "python",
@@ -39,6 +47,16 @@ suite("Extension Test Suite", () => {
 
     const line = 3;
     const character = 5;
+    const position = new vscode.Position(line, character);
+    const hover = myExtension.PythonHover.provideHover(document, position);
+    assert.ok(hover);
+  });
+
+  test("should return hover content when hovering over a function", async () => {
+    const document = await createTestDocument(ASYNC_BASIC_CONTENT);
+
+    const line = 3;
+    const character = 11;
     const position = new vscode.Position(line, character);
     const hover = myExtension.PythonHover.provideHover(document, position);
     assert.ok(hover);


### PR DESCRIPTION
This PR has the same purpose as #34 and will get the same fate:
- checked out the `v0.2.0` tag
- updated the TypeScript plugin per its `v0.4.0` release
- run tests
- bumped the version of VSCode extension to `v0.2.1`

The compiled extension will now be published to the marketplace as `v0.2.1` and this PR will be closed.