### PR TITLE
Sync main with release after 0 2 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
   `fiberplane-charts` directly from a workspace repository. The problem with
   packaging has been solved with a Yarn plugin.
 
+# 0.2.1
+
+- [chore] update TS plugin dependency to `v0.4.0`
+
+## 0.2.0
+
+- [fix] add support for async functions in python
 ## 0.1.0
 
 - [python] Improved detection logic: Now multiple decorators are supported

--- a/README.md
+++ b/README.md
@@ -44,3 +44,5 @@ extensions:
 
 Create a new release using Github which matches the version number it should be
 released under.
+
+After tagging and releasing, merge `main` into the `release` branch. (The `release` branch should always reflect the latest released version on VSCode marketplate.)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "displayName": "Autometrics",
   "license": "MIT",
   "description": "Show enhanced autometrics information from your code",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/autometrics-dev/vscode-autometrics"
@@ -120,7 +120,7 @@
     "rome": "^12.0.0"
   },
   "dependencies": {
-    "@autometrics/typescript-plugin": "^0.3.0",
+    "@autometrics/typescript-plugin": "^0.4.0",
     "@msgpack/msgpack": "^3.0.0-beta2",
     "byte-base64": "^1.1.0",
     "fiberplane-charts": "git+https://git@github.com/fiberplane/fiberplane.git#workspace=fiberplane-charts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,10 +5,10 @@ __metadata:
   version: 6
   cacheKey: 8
 
-"@autometrics/typescript-plugin@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@autometrics/typescript-plugin@npm:0.3.0"
-  checksum: f5705b8323d16c589331a5de9d6fa6aad99bfdc2201042b853c47711b3818f910770a3a1a3f86e5d8bf9c767b5e7b2b564f1a1e070e7e5f151b696576459406d
+"@autometrics/typescript-plugin@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@autometrics/typescript-plugin@npm:0.4.0"
+  checksum: faffdd21642e9308627d258ff25d427971bbade091946ed9dc386894a5428d48d9bd5cd7625347270f535f68cc958edd318cfeed0f58ff024947741be3826f8b
   languageName: node
   linkType: hard
 
@@ -1007,7 +1007,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "autometrics@workspace:."
   dependencies:
-    "@autometrics/typescript-plugin": ^0.3.0
+    "@autometrics/typescript-plugin": ^0.4.0
     "@msgpack/msgpack": ^3.0.0-beta2
     "@types/glob": ^8.1.0
     "@types/mocha": ^10.0.1


### PR DESCRIPTION
This PR is the last of some convoluted branch syncing after Lau and I backported some changes in main to publish new releases of the extension (0.2.0 - support of async python functions, and 0.2.1 - support for the 0.4.0 \@autometrics/typescript-plugin dep)

This PR just updates:

- CHANGELOG, to mention the 0.2.0 and 0.2.1 releases
- README, to mention merging latest released changes into the new `release` branch
- package.json + yarn.lock, to reflect the  the 0.4.0 \@autometrics/typescript-plugin dep