### PR TITLE
Fix stuck panel options

### DIFF
--- a/src/chartPanel.ts
+++ b/src/chartPanel.ts
@@ -63,6 +63,7 @@ function createChartPanel(
   prometheus: Prometheus,
   options: PanelOptions,
 ): ChartPanel {
+  let currentOptions = options;
   const panel = vscode.window.createWebviewPanel(
     "autometricsChart",
     getTitle(options),
@@ -75,6 +76,7 @@ function createChartPanel(
   }
 
   function update(options: PanelOptions) {
+    currentOptions = options;
     panel.title = getTitle(options);
     postMessage({ type: "show_panel", options });
   }
@@ -83,7 +85,7 @@ function createChartPanel(
     (message: MessageFromWebview) => {
       switch (message.type) {
         case "ready":
-          update(options);
+          update(currentOptions);
           return;
         case "request_data": {
           const { query, timeRange, id } = message;


### PR DESCRIPTION
When you had a panel still open and wanted to view a different the panel would receive focus but the panel options it would receive would still be the original options.