### PR TITLE
TypeScript plugin update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-# Change Log
+# Changelog
 
-## [Unreleased]
+## [0.4.0]
 - Add date picker to the function metrics panel
+- [chore] update TypeScript plugin dependency
 
 # 0.3.0
 - [chore] Upgrade several dependencies

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "rome": "^12.1.0"
   },
   "dependencies": {
-    "@autometrics/typescript-plugin": "^0.4.0",
+    "@autometrics/typescript-plugin": "latest",
     "@msgpack/msgpack": "^3.0.0-beta2",
     "byte-base64": "^1.1.0",
     "fiberplane-charts": "git+https://git@github.com/fiberplane/fiberplane.git#workspace=fiberplane-charts",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "displayName": "Autometrics",
   "license": "MIT",
   "description": "Show enhanced autometrics information from your code",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/autometrics-dev/vscode-autometrics"
@@ -122,7 +122,7 @@
     "rome": "^12.1.0"
   },
   "dependencies": {
-    "@autometrics/typescript-plugin": "latest",
+    "@autometrics/typescript-plugin": "^0.5.0",
     "@msgpack/msgpack": "^3.0.0-beta2",
     "byte-base64": "^1.1.0",
     "fiberplane-charts": "git+https://git@github.com/fiberplane/fiberplane.git#workspace=fiberplane-charts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,7 +5,7 @@ __metadata:
   version: 6
   cacheKey: 8
 
-"@autometrics/typescript-plugin@npm:latest":
+"@autometrics/typescript-plugin@npm:^0.5.0":
   version: 0.5.0
   resolution: "@autometrics/typescript-plugin@npm:0.5.0"
   checksum: 286f79f6a4b9a86e1c372d1a0e4c0ae14cffe92b51cfc8399af2837296c327036bfbd17e521e9e6c566a63806c1039e06d195483a0c006e5fe74cb950bb2e15a
@@ -1032,7 +1032,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "autometrics@workspace:."
   dependencies:
-    "@autometrics/typescript-plugin": latest
+    "@autometrics/typescript-plugin": ^0.5.0
     "@msgpack/msgpack": ^3.0.0-beta2
     "@types/glob": ^8.1.0
     "@types/mocha": ^10.0.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,10 +5,10 @@ __metadata:
   version: 6
   cacheKey: 8
 
-"@autometrics/typescript-plugin@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "@autometrics/typescript-plugin@npm:0.4.0"
-  checksum: faffdd21642e9308627d258ff25d427971bbade091946ed9dc386894a5428d48d9bd5cd7625347270f535f68cc958edd318cfeed0f58ff024947741be3826f8b
+"@autometrics/typescript-plugin@npm:latest":
+  version: 0.5.0
+  resolution: "@autometrics/typescript-plugin@npm:0.5.0"
+  checksum: 286f79f6a4b9a86e1c372d1a0e4c0ae14cffe92b51cfc8399af2837296c327036bfbd17e521e9e6c566a63806c1039e06d195483a0c006e5fe74cb950bb2e15a
   languageName: node
   linkType: hard
 
@@ -1032,7 +1032,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "autometrics@workspace:."
   dependencies:
-    "@autometrics/typescript-plugin": ^0.4.0
+    "@autometrics/typescript-plugin": latest
     "@msgpack/msgpack": ^3.0.0-beta2
     "@types/glob": ^8.1.0
     "@types/mocha": ^10.0.1


### PR DESCRIPTION
This update bumps the TypeScript plugin dependency to always the pull latest stable from NPM

- set VSCode to always pull latest TypeScript plugin from npm
- bump minor version and update changelog
