### PR TITLE
Enable toggling elements via legend

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "@floating-ui/react": "^0.24.2",
     "@msgpack/msgpack": "^3.0.0-beta2",
     "byte-base64": "^1.1.0",
-    "fiberplane-charts": "git+https://git@github.com/fiberplane/fiberplane.git#workspace=fiberplane-charts",
+    "fiberplane-charts": "fiberplane/fiberplane#head=legend_toggle&workspace=fiberplane-charts",
     "framer-motion": "^10.12.16",
     "node-fetch": "^2.0.0",
     "react": "^18.2.0",

--- a/src/charts/components/FunctionCharts/FunctionChart.tsx
+++ b/src/charts/components/FunctionCharts/FunctionChart.tsx
@@ -70,6 +70,39 @@ export function FunctionChart(props: Props) {
             setTooltip({ anchor, content });
             return () => setTooltip(null);
           }}
+          onToggleTimeseriesVisibility={
+            timeSeries && timeSeries.length > 1
+              ? ({ timeseries: relevantTimeseries, toggleOthers }) => {
+                  const graph = state.graphs[id];
+                  if (!graph || !graph.timeSeries) {
+                    return;
+                  }
+                  const selectedIndex = timeSeries.indexOf(relevantTimeseries);
+
+                  // Can't find the index? Bail out
+                  if (selectedIndex === -1) {
+                    return;
+                  }
+
+                  if (toggleOthers) {
+                    const othersVisible = graph.timeSeries.some(
+                      (ts, index) => ts.visible && index !== selectedIndex,
+                    );
+
+                    graph.timeSeries.forEach((ts, index) => {
+                      if (index !== selectedIndex) {
+                        ts.visible = !othersVisible;
+                      } else {
+                        ts.visible = true;
+                      }
+                    });
+                  } else {
+                    graph.timeSeries[selectedIndex].visible =
+                      !relevantTimeseries.visible;
+                  }
+                }
+              : undefined
+          }
         />
       </Content>
       {showingQuery && <CodeBlock query={query} />}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1101,7 +1101,7 @@ __metadata:
     byte-base64: ^1.1.0
     concurrently: ^8.0.1
     esbuild: ^0.17.19
-    fiberplane-charts: "git+https://git@github.com/fiberplane/fiberplane.git#workspace=fiberplane-charts"
+    fiberplane-charts: "fiberplane/fiberplane#head=legend_toggle&workspace=fiberplane-charts"
     framer-motion: ^10.12.16
     glob: ^8.1.0
     mocha: ^10.2.0
@@ -1984,9 +1984,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fiberplane-charts@git+https://git@github.com/fiberplane/fiberplane.git#workspace=fiberplane-charts":
+"fiberplane-charts@fiberplane/fiberplane#head=legend_toggle&workspace=fiberplane-charts":
   version: 0.1.0
-  resolution: "fiberplane-charts@https://git@github.com/fiberplane/fiberplane.git#workspace=fiberplane-charts&commit=c84d3ac1fa6509bc8451f0681504fc0b4929f927"
+  resolution: "fiberplane-charts@https://github.com/fiberplane/fiberplane.git#workspace=fiberplane-charts&commit=c3d2086babb614b1153adc2b1010754e8c4b5023"
   dependencies:
     "@types/d3-scale": ^4.0.3
     "@visx/axis": ^3.1.0
@@ -2005,7 +2005,7 @@ __metadata:
     react: ^18.0.0
     react-dom: ^18.0.0
     styled-components: ^5.3.0
-  checksum: 50b9bcf488a67b1b9b9125a4c1a17b7a2e68ab414e2d84e7cf13be2cf6c0d1fefebf7c2484ee069b3c996df5cd415d56adcedab241ab7be648176dd4e37aae6f
+  checksum: dbc9fba9a06306c9daefb10727cbf4619dd75d507874ff8ee40e19cad25091767e5d0fd8925db312b14778cbd93a53cbae41b4305c71096b817a3e016f173f24
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR uses the changes introduced in: https://github.com/fiberplane/fiberplane/pull/64

To enable toggling series on/off in charts.

I'll update this PR when the pr on the fiberplane repo is merged