### PR TITLE
Update hover tooltips for typescript 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - add toggle for showing/hiding PromQL queries
 - add support for the "module" label for certain graphs
 - add tooltips to the graphs
+- update bundled typescript plugin which contains fixes for usage in combination with typescript 5
 
 ## [0.4.0]
 - Add date picker to the function metrics panel

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "vitest": "^0.32.0"
   },
   "dependencies": {
-    "@autometrics/typescript-plugin": "^0.5.2",
+    "@autometrics/typescript-plugin": "^0.5.3",
     "@floating-ui/core": "^1.2.6",
     "@floating-ui/react": "^0.24.2",
     "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "vitest": "^0.32.0"
   },
   "dependencies": {
-    "@autometrics/typescript-plugin": "^0.5.0",
+    "@autometrics/typescript-plugin": "^0.5.2",
     "@floating-ui/core": "^1.2.6",
     "@floating-ui/react": "^0.24.2",
     "@msgpack/msgpack": "^3.0.0-beta2",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,13 +16,13 @@ declare const WebAssembly: any;
 export async function activate(context: vscode.ExtensionContext) {
   activatePythonSupport();
   activateRustSupport();
-  activateTypeScriptSupport();
+  await activateTypeScriptSupport();
 
   const config = getAutometricsConfig();
   const prometheusUrl = getPrometheusUrl(config);
   const prometheus = await loadPrometheusProvider(prometheusUrl);
 
-  activateSidebar(prometheus);
+  await activateSidebar(prometheus);
   registerChartPanel(context, prometheus);
 }
 

--- a/src/functionHover.ts
+++ b/src/functionHover.ts
@@ -7,8 +7,8 @@ import { PanelOptions } from "./chartPanel";
  * Creates a VS Code hover for the given function.
  */
 export function createFunctionHover(functionName: string): vscode.Hover {
-  const content = `## Autometrics
-[View the live metrics](${getOpenPanelCommand({
+  const content = `### Autometrics 
+  [**View metrics**](${getOpenPanelCommand({
     type: "function_graphs",
     functionName,
   })})

--- a/src/languages/typescript/typescript.ts
+++ b/src/languages/typescript/typescript.ts
@@ -30,10 +30,11 @@ export async function activateTypeScriptSupport() {
     const config = getAutometricsConfig();
     const prometheusUrl = getPrometheusUrl(config);
     console.log(`Configuring TS plugin with ${prometheusUrl}`);
-    api.configurePlugin(tsPluginId, {
+    const options = {
       prometheusUrl,
-      quickInfoMode: "html-comment",
-    });
+      docsOutputFormat: "vscode",
+    };
+    api.configurePlugin(tsPluginId, options);
   }
 
   configureTSPlugin(tsExtensionApi);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,10 +5,10 @@ __metadata:
   version: 6
   cacheKey: 8
 
-"@autometrics/typescript-plugin@npm:^0.5.2":
-  version: 0.5.2
-  resolution: "@autometrics/typescript-plugin@npm:0.5.2"
-  checksum: d60667db6c83ca51b3c4bcd3829915b367c03851201e6dbc20016f1da1a7d12f4153600c11779d621ef1b73fd38b2743b5075f44b694460651cd9f6371286ee6
+"@autometrics/typescript-plugin@npm:^0.5.3":
+  version: 0.5.3
+  resolution: "@autometrics/typescript-plugin@npm:0.5.3"
+  checksum: e0911453a383f60b3dfa98c5845ba5ba292aca7a2eb98cc3731b93b99b1982bb7dc56802498c9d7c35b4bce00ccbbd8ce772a5f54525e257e0caac0cd7c886c4
   languageName: node
   linkType: hard
 
@@ -1183,7 +1183,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "autometrics@workspace:."
   dependencies:
-    "@autometrics/typescript-plugin": ^0.5.2
+    "@autometrics/typescript-plugin": ^0.5.3
     "@floating-ui/core": ^1.2.6
     "@floating-ui/react": ^0.24.2
     "@msgpack/msgpack": ^3.0.0-beta2

--- a/yarn.lock
+++ b/yarn.lock
@@ -2172,7 +2172,7 @@ __metadata:
 
 "fiberplane-charts@git+https://git@github.com/fiberplane/fiberplane.git#workspace=fiberplane-charts":
   version: 0.1.0
-  resolution: "fiberplane-charts@https://git@github.com/fiberplane/fiberplane.git#workspace=fiberplane-charts&commit=284507713449e19ff55e56017fb6ec5644107d18"
+  resolution: "fiberplane-charts@https://git@github.com/fiberplane/fiberplane.git#workspace=fiberplane-charts&commit=368e0fad163f3d5b79974bb6f649e97fd5a3457c"
   dependencies:
     "@types/d3-scale": ^4.0.3
     "@visx/axis": ^3.1.0
@@ -2191,7 +2191,7 @@ __metadata:
     react: ^18.0.0
     react-dom: ^18.0.0
     styled-components: ^5.3.0
-  checksum: dbc9fba9a06306c9daefb10727cbf4619dd75d507874ff8ee40e19cad25091767e5d0fd8925db312b14778cbd93a53cbae41b4305c71096b817a3e016f173f24
+  checksum: bd23306b97cbd638c221a657e6253c157d0b1eb187c9aea1f9b909a9f62718d70efca68f6eed823355775b1a8055f7d99111c2552aeb026067b2e18617222055
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,10 +5,10 @@ __metadata:
   version: 6
   cacheKey: 8
 
-"@autometrics/typescript-plugin@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "@autometrics/typescript-plugin@npm:0.5.0"
-  checksum: 286f79f6a4b9a86e1c372d1a0e4c0ae14cffe92b51cfc8399af2837296c327036bfbd17e521e9e6c566a63806c1039e06d195483a0c006e5fe74cb950bb2e15a
+"@autometrics/typescript-plugin@npm:^0.5.2":
+  version: 0.5.2
+  resolution: "@autometrics/typescript-plugin@npm:0.5.2"
+  checksum: d60667db6c83ca51b3c4bcd3829915b367c03851201e6dbc20016f1da1a7d12f4153600c11779d621ef1b73fd38b2743b5075f44b694460651cd9f6371286ee6
   languageName: node
   linkType: hard
 
@@ -1183,7 +1183,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "autometrics@workspace:."
   dependencies:
-    "@autometrics/typescript-plugin": ^0.5.0
+    "@autometrics/typescript-plugin": ^0.5.2
     "@floating-ui/core": ^1.2.6
     "@floating-ui/react": ^0.24.2
     "@msgpack/msgpack": ^3.0.0-beta2


### PR DESCRIPTION
By adding a HoverProvider and updating the bundled @autometrics/typescript-plugin so it creates special "hover" information as an html-comment which in turn can be parsed by the extension.

This requires https://github.com/autometrics-dev/autometrics-ts/pull/72 to be merged in and released.

TODO before release:
* [x] update `@autometrics/typescript-plugin` dependency 

If people want to test this locally, they need to:
* clone the autometrics-dev/autometrics-ts repo
* checkout the `html-comment` branch
* run `npm install` and `npm run build`
* install it via a relative path (i.e. `yarn add "../autometrics-ts/packages/typescript-plugin"`)