### PR TITLE
Improved autometrics `am` explorer integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "properties": {
           "autometrics.prometheusUrl": {
             "type": "string",
+            "format": "uri",
             "description": "Enter the base URL for your prometheus instance, this URL is used to generate links for queries",
             "default": "http://localhost:9090"
           },
@@ -46,18 +47,31 @@
             "description": "Enable experimental support for Rust",
             "default": false
           },
-          "autometrics.graph.graphPreferences": {
+          "autometrics.graphPreferences": {
             "type": "string",
-            "description": "The extension can (for supported languages) link to either the embedded graphs (default) or to the prometheus web interface",
+            "markdownDescription": "The extension can (for supported languages) link to: the embedded graphs (default), Prometheus web interface or the Autometrics explorer web interface (see for more information the [Autometrics local development](https://docs.autometrics.dev/local-development) documentation)",
             "default": "embedded",
             "enum": [
               "embedded",
-              "prometheus"
+              "prometheus",
+              "explorer"
             ],
             "enumItemLabels": [
               "Use the embedded graphs",
-              "Link out to prometheus"
+              "Link out to prometheus",
+              "Use autometrics explorer"
+            ],
+            "markdownEnumDescriptions": [
+              "The extension will show the graphs in the editor",
+              "The extension will link to the prometheus web interface",
+              "The extension will link to the autometrics explorer web interface"
             ]
+          },
+          "autometrics.webServerURL": {
+            "type": "string",
+            "markdownDescription": "If you use the [autometrics CLI](https://github.com/autometrics-dev/am) you can use the bundled web interface to explore autometrics data. In order to use this you should set `#autometrics.graphPreferences#` to the `Use autometrics explorer` option.\n\n**Note** This URL only needs to be changed if you're running the server on a different port.",
+            "format": "uri",
+            "default": "http://localhost:6789"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
           },
           "autometrics.graphPreferences": {
             "type": "string",
-            "markdownDescription": "The extension can (for supported languages) link to: the embedded graphs (default), Prometheus web interface or the Autometrics explorer web interface (see for more information the [Autometrics local development](https://docs.autometrics.dev/local-development) documentation)",
+            "markdownDescription": "The extension can (for supported languages) link to: the embedded graphs (default), Prometheus web interface or the Autometrics explorer web interface (see for more information the [Autometrics local development](https://docs.autometrics.dev/local-development) documentation).\n\n **Note:** the Autometrics explorer web interface doesn't support all possible graphs yet so the embedded graphs are used as a fallback in some cases.",
             "default": "embedded",
             "enum": [
               "embedded",

--- a/src/chartPanel.ts
+++ b/src/chartPanel.ts
@@ -74,7 +74,10 @@ export function registerChartPanel(
     async (options: PanelOptions) => {
       const config = getAutometricsConfig();
       const graphPreferences = getGraphPreferences(config);
-      if (graphPreferences === "embedded") {
+      if (
+        graphPreferences === "embedded" ||
+        (graphPreferences === "explorer" && options.type === "metric")
+      ) {
         // Reuse existing panel if available.
         if (chartPanel) {
           await chartPanel.update(options);
@@ -87,6 +90,7 @@ export function registerChartPanel(
           chartPanel = null;
         });
         chartPanel = panel;
+        return;
       }
 
       const prometheusUrl =

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,10 +30,10 @@ export function getGraphPreferences(
 }
 
 export function getPrometheusUrl(config: AutometricsConfig): string {
-  return config.prometheusUrl || "http://localhost:9090/";
+  return config.prometheusUrl || "http://localhost:9090";
 }
 
 export function getExplorerUrl(config: AutometricsConfig): string {
-  const baseUrl = config.webServerURL || "http://localhost:6789/";
+  const baseUrl = config.webServerURL || "http://localhost:6789";
   return `${baseUrl.replace(/\/$/, "")}`;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,14 @@
 import * as vscode from "vscode";
 
+type GraphPreference = "embedded" | "prometheus" | "explorer";
+
 // Make sure to keep this in sync with the
 // "contributes.configuration.properties" section in the `package.json`.
 export type AutometricsConfig = {
   prometheusUrl?: string;
   experimentalRustSupport?: boolean;
-  graphPreferences?: "embedded" | "prometheus";
+  graphPreferences?: GraphPreference;
+  webServerURL?: string;
 };
 
 const configSection = "autometrics";
@@ -20,6 +23,17 @@ export function getAutometricsConfig(): AutometricsConfig {
   return vscode.workspace.getConfiguration(configSection) as AutometricsConfig;
 }
 
+export function getGraphPreferences(
+  config: AutometricsConfig,
+): GraphPreference {
+  return config.graphPreferences || "embedded";
+}
+
 export function getPrometheusUrl(config: AutometricsConfig): string {
   return config.prometheusUrl || "http://localhost:9090/";
+}
+
+export function getExplorerUrl(config: AutometricsConfig): string {
+  const baseUrl = config.webServerURL || "http://localhost:6789/";
+  return `${baseUrl.replace(/\/$/, "")}/explorer`;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,5 +35,5 @@ export function getPrometheusUrl(config: AutometricsConfig): string {
 
 export function getExplorerUrl(config: AutometricsConfig): string {
   const baseUrl = config.webServerURL || "http://localhost:6789/";
-  return `${baseUrl.replace(/\/$/, "")}/explorer`;
+  return `${baseUrl.replace(/\/$/, "")}`;
 }

--- a/src/functionHover.ts
+++ b/src/functionHover.ts
@@ -44,8 +44,6 @@ function createEmbeddedHover(functionName: string): vscode.Hover {
   return new vscode.Hover(markdown);
 }
 
-// const DEFAULT_URL = "http://localhost:9090";
-
 function createPrometheusHover(
   functionName: string,
   moduleName?: string,

--- a/src/languages/rust/experimental.ts
+++ b/src/languages/rust/experimental.ts
@@ -1,0 +1,91 @@
+import * as vscode from "vscode";
+
+import { RustHover } from "./hover";
+import {
+  getRustAnalyzerConfig,
+  isRustAnalyzerInstalled,
+  updateRustAnalyzerSettings,
+} from "./rust-analyzer";
+
+let hoverProviderDisposable: vscode.Disposable | undefined;
+let rustAnalyzerMonitorDisposable: vscode.Disposable | undefined;
+
+/**
+ * This function will enable/activate all rust related features
+ */
+export async function activateExperimentalSupport(
+  context: vscode.ExtensionContext,
+) {
+  if (!hoverProviderDisposable) {
+    hoverProviderDisposable = vscode.languages.registerHoverProvider(
+      "rust",
+      RustHover,
+    );
+    context.subscriptions.push(hoverProviderDisposable);
+  }
+
+  if (isRustAnalyzerInstalled()) {
+    // Next: disable the rust-analyzer docs by setting an environment variable.
+    await updateAutometricsDocsSetting(context);
+  } else {
+    vscode.window.showErrorMessage(
+      "Rust-analyzer extension is not installed or not active. Please install the extension and try again.",
+    );
+
+    if (!rustAnalyzerMonitorDisposable) {
+      rustAnalyzerMonitorDisposable = vscode.extensions.onDidChange(() => {
+        if (isRustAnalyzerInstalled()) {
+          updateAutometricsDocsSetting(context);
+        }
+      });
+
+      context.subscriptions.push(rustAnalyzerMonitorDisposable);
+    }
+  }
+}
+
+/**
+ * This function removes all rust related features
+ */
+export function cleanupExperimentalSupport(context: vscode.ExtensionContext) {
+  if (hoverProviderDisposable) {
+    hoverProviderDisposable.dispose();
+    const index = context.subscriptions.indexOf(hoverProviderDisposable);
+    if (index !== -1) {
+      context.subscriptions.splice(index, 1);
+    }
+    hoverProviderDisposable = undefined;
+  }
+
+  if (rustAnalyzerMonitorDisposable) {
+    rustAnalyzerMonitorDisposable.dispose();
+    const index = context.subscriptions.indexOf(rustAnalyzerMonitorDisposable);
+    if (index !== -1) {
+      context.subscriptions.splice(index, 1);
+    }
+    rustAnalyzerMonitorDisposable = undefined;
+  }
+}
+
+export function updateAutometricsDocsSetting(context: vscode.ExtensionContext) {
+  const shouldUpdate = () => {
+    const config = getRustAnalyzerConfig();
+    const extraEnv = config.server?.extraEnv || {};
+    return extraEnv.AUTOMETRICS_DISABLE_DOCS !== "1";
+  };
+
+  const updateSettings = async () => {
+    const config = getRustAnalyzerConfig();
+    const extraEnv = config.server?.extraEnv || {};
+    await config.update("server.extraEnv", {
+      ...extraEnv,
+      AUTOMETRICS_DISABLE_DOCS: "1",
+    });
+  };
+
+  return updateRustAnalyzerSettings(context, {
+    checkKey: "rustConfigChecked",
+    shouldUpdate,
+    updateSettings,
+  });
+}

--- a/src/languages/rust/explorer.ts
+++ b/src/languages/rust/explorer.ts
@@ -35,7 +35,7 @@ export function activateExplorer(context: vscode.ExtensionContext) {
 }
 
 export async function deactivateExplorer(context: vscode.ExtensionContext) {
-  if (usesExplorerUrl() === false) {
+  if (usesExplorerUrl() === true) {
     await withAnalyzerConfigRestart(async () => {
       const config = getRustAnalyzerConfig();
       const { PROMETHEUS_URL: _, ...extraEnv } = config.server?.extraEnv || {};

--- a/src/languages/rust/explorer.ts
+++ b/src/languages/rust/explorer.ts
@@ -1,0 +1,49 @@
+import * as vscode from "vscode";
+import { getAutometricsConfig, getExplorerUrl } from "../../config";
+import {
+  getRustAnalyzerConfig,
+  resetWorkspaceStateKey,
+  updateRustAnalyzerSettings,
+  withAnalyzerConfigRestart,
+} from "./rust-analyzer";
+
+const EXPLORER_KEY = "explorer";
+
+function usesExplorerUrl() {
+  const prometheusUrl = getExplorerUrl(getAutometricsConfig());
+  const config = getRustAnalyzerConfig();
+  const extraEnv = config.server?.extraEnv || {};
+  return extraEnv.PROMETHEUS_URL === prometheusUrl;
+}
+
+async function updateSettings() {
+  const prometheusUrl = getExplorerUrl(getAutometricsConfig());
+  const config = getRustAnalyzerConfig();
+  const extraEnv = config.server?.extraEnv || {};
+  await config.update("server.extraEnv", {
+    ...extraEnv,
+    PROMETHEUS_URL: prometheusUrl,
+  });
+}
+
+export function activateExplorer(context: vscode.ExtensionContext) {
+  return updateRustAnalyzerSettings(context, {
+    checkKey: EXPLORER_KEY,
+    shouldUpdate: () => usesExplorerUrl() === false,
+    updateSettings,
+  });
+}
+
+export async function deactivateExplorer(context: vscode.ExtensionContext) {
+  if (usesExplorerUrl() === false) {
+    await withAnalyzerConfigRestart(async () => {
+      const config = getRustAnalyzerConfig();
+      const { PROMETHEUS_URL: _, ...extraEnv } = config.server?.extraEnv || {};
+      await config.update("server.extraEnv", {
+        ...extraEnv,
+      });
+    });
+  }
+
+  await resetWorkspaceStateKey(context, EXPLORER_KEY);
+}

--- a/src/languages/rust/hover.ts
+++ b/src/languages/rust/hover.ts
@@ -1,0 +1,27 @@
+import * as vscode from "vscode";
+
+import { createFunctionHover } from "../../functionHover";
+
+export const RustHover = {
+  provideHover(document: vscode.TextDocument, position: vscode.Position) {
+    const name = getFunctionName(document, position);
+    if (name) {
+      return createFunctionHover(name);
+    }
+
+    return undefined;
+  },
+};
+
+// HACK: This is an incredibly naive hack that will just show a tooltip for
+//       every function. We should replace this with a proper parsing solution.
+//       See: https://github.com/autometrics-dev/vscode-autometrics/issues/29
+function getFunctionName(
+  document: vscode.TextDocument,
+  position: vscode.Position,
+): string | void {
+  const textLine = document.lineAt(position.line);
+  const functionRegex = /fn\s*(?<name>[\dA-z]+)?\s*\(/;
+  const match = textLine.text.match(functionRegex);
+  return match?.groups?.name;
+}

--- a/src/languages/rust/rust-analyzer.ts
+++ b/src/languages/rust/rust-analyzer.ts
@@ -24,7 +24,9 @@ export async function updateRustAnalyzerSettings(
     return;
   }
 
-  // shouldUpdate
+  // verify if the settings need to be updated
+  // we don't want to update the settings if they are already set
+  // restarting the rust-analyzer server is expensive
   if (shouldUpdate()) {
     await withAnalyzerConfigRestart(updateSettings);
   }

--- a/src/languages/rust/rust-analyzer.ts
+++ b/src/languages/rust/rust-analyzer.ts
@@ -1,0 +1,76 @@
+import * as vscode from "vscode";
+
+export function isRustAnalyzerInstalled() {
+  const hasExtension = vscode.extensions.getExtension(
+    "rust-lang.rust-analyzer",
+  );
+
+  return !!hasExtension;
+}
+
+export async function updateRustAnalyzerSettings(
+  context: vscode.ExtensionContext,
+  options: {
+    checkKey: string; // The key to check if we've already set this setting
+    shouldUpdate: () => boolean; // A function to check if we should update the setting
+    updateSettings: () => Promise<void>; // A function to update the setting
+  },
+) {
+  const { checkKey, shouldUpdate, updateSettings } = options;
+  // But first, check if we've already done this before
+  // and if so, don't set it again. People may have changed the config on purpose
+  // and the extension should respect that.
+  if (isWorkspaceKeySet(context, checkKey)) {
+    return;
+  }
+
+  // shouldUpdate
+  if (shouldUpdate()) {
+    await withAnalyzerConfigRestart(updateSettings);
+  }
+
+  setWorkspaceStateKey(context, options.checkKey);
+}
+
+export function getRustAnalyzerConfig() {
+  return vscode.workspace.getConfiguration("rust-analyzer");
+}
+
+export function isWorkspaceKeySet(
+  context: vscode.ExtensionContext,
+  key: string,
+) {
+  return context.workspaceState.get(key) === true;
+}
+
+export function setWorkspaceStateKey(
+  context: vscode.ExtensionContext,
+  key: string,
+) {
+  return context.workspaceState.update(key, true);
+}
+
+export function resetWorkspaceStateKey(
+  context: vscode.ExtensionContext,
+  key: string,
+) {
+  return context.workspaceState.update(key, undefined);
+}
+
+// This configures the rust-analyzer to restart on config change and after the updater is done, reverts that change
+export async function withAnalyzerConfigRestart(updater: () => Promise<void>) {
+  const config = getRustAnalyzerConfig();
+
+  const initialRestartValue = config.restartServerOnConfigChange;
+  if (!initialRestartValue) {
+    // The extension will (temporarily) set the rust-analyzer to restart on config change
+    await config.update("restartServerOnConfigChange", true);
+  }
+
+  await updater();
+
+  // Restore the value if it was not originally set to true
+  if (initialRestartValue !== true) {
+    await config.update("restartServerOnConfigChange", initialRestartValue);
+  }
+}

--- a/src/languages/rust/rust.ts
+++ b/src/languages/rust/rust.ts
@@ -1,7 +1,11 @@
 import * as vscode from "vscode";
 
-import { createFunctionHover } from "../../functionHover";
-import { getAutometricsConfig } from "../../config";
+import { getAutometricsConfig, getGraphPreferences } from "../../config";
+import {
+  activateExperimentalSupport,
+  cleanupExperimentalSupport,
+} from "./experimental";
+import { activateExplorer, deactivateExplorer } from "./explorer";
 
 // TODO: See https://github.com/autometrics-dev/vscode-autometrics/issues/27
 //       for tracking the Rust implementation.
@@ -15,64 +19,6 @@ export async function activateRustSupport(context: vscode.ExtensionContext) {
   await init(context);
 }
 
-let hoverProviderDisposable: vscode.Disposable | undefined;
-let rustAnalyzerMonitorDisposable: vscode.Disposable | undefined;
-
-/**
- * This function will enable/activate all rust related features
- */
-async function activateExperimentalSupport(context: vscode.ExtensionContext) {
-  if (!hoverProviderDisposable) {
-    hoverProviderDisposable = vscode.languages.registerHoverProvider(
-      "rust",
-      RustHover,
-    );
-    context.subscriptions.push(hoverProviderDisposable);
-  }
-
-  if (isRustAnalyzerInstalled()) {
-    // Next: disable the rust-analyzer docs by setting an environment variable.
-    await updateAutometricsDocsSetting(context);
-  } else {
-    vscode.window.showErrorMessage(
-      "Rust-analyzer extension is not installed or not active. Please install the extension and try again.",
-    );
-
-    if (!rustAnalyzerMonitorDisposable) {
-      rustAnalyzerMonitorDisposable = vscode.extensions.onDidChange(() => {
-        if (isRustAnalyzerInstalled()) {
-          updateAutometricsDocsSetting(context);
-        }
-      });
-
-      context.subscriptions.push(rustAnalyzerMonitorDisposable);
-    }
-  }
-}
-
-/**
- * This function removes all rust related features
- */
-function cleanupExperimentalSupport(context: vscode.ExtensionContext) {
-  if (hoverProviderDisposable) {
-    hoverProviderDisposable.dispose();
-    const index = context.subscriptions.indexOf(hoverProviderDisposable);
-    if (index !== -1) {
-      context.subscriptions.splice(index, 1);
-    }
-    hoverProviderDisposable = undefined;
-  }
-
-  if (rustAnalyzerMonitorDisposable) {
-    rustAnalyzerMonitorDisposable.dispose();
-    const index = context.subscriptions.indexOf(rustAnalyzerMonitorDisposable);
-    if (index !== -1) {
-      context.subscriptions.splice(index, 1);
-    }
-    rustAnalyzerMonitorDisposable = undefined;
-  }
-}
-
 async function init(context: vscode.ExtensionContext) {
   const config = getAutometricsConfig();
   if (config.experimentalRustSupport) {
@@ -80,72 +26,12 @@ async function init(context: vscode.ExtensionContext) {
   } else {
     cleanupExperimentalSupport(context);
   }
-}
 
-function isRustAnalyzerInstalled() {
-  const hasExtension = vscode.extensions.getExtension(
-    "rust-lang.rust-analyzer",
-  );
+  const graphPreferences = getGraphPreferences(config);
 
-  return !!hasExtension;
-}
-
-async function updateAutometricsDocsSetting(context: vscode.ExtensionContext) {
-  const rustAnalyzerConfig = vscode.workspace.getConfiguration("rust-analyzer");
-
-  // But first, check if we've already done this before
-  // and if so, don't set it again. People may have changed the config on purpose
-  // and the extension should respect that.
-  const rustConfigChecked = context.workspaceState.get("rustConfigChecked");
-  if (rustConfigChecked === "true") {
-    return;
+  if (graphPreferences === "explorer") {
+    await activateExplorer(context);
+  } else {
+    await deactivateExplorer(context);
   }
-
-  const extraEnv = rustAnalyzerConfig.server?.extraEnv || {};
-  if (extraEnv.AUTOMETRICS_DISABLE_DOCS !== "1") {
-    // The extension will (temporarily) set the rust-analyzer to reload on config change
-    const initialRestartValue = rustAnalyzerConfig.restartServerOnConfigChange;
-    if (!initialRestartValue) {
-      await rustAnalyzerConfig.update("restartServerOnConfigChange", true);
-    }
-
-    await rustAnalyzerConfig.update("server.extraEnv", {
-      ...extraEnv,
-      AUTOMETRICS_DISABLE_DOCS: "1",
-    });
-
-    // Restore the value if it was not originally set to true
-    if (initialRestartValue !== true) {
-      await rustAnalyzerConfig.update(
-        "restartServerOnConfigChange",
-        initialRestartValue,
-      );
-    }
-  }
-
-  context.workspaceState.update("rustConfigChecked", true);
-}
-
-export const RustHover = {
-  provideHover(document: vscode.TextDocument, position: vscode.Position) {
-    const name = getFunctionName(document, position);
-    if (name) {
-      return createFunctionHover(name);
-    }
-
-    return undefined;
-  },
-};
-
-// HACK: This is an incredibly naive hack that will just show a tooltip for
-//       every function. We should replace this with a proper parsing solution.
-//       See: https://github.com/autometrics-dev/vscode-autometrics/issues/29
-function getFunctionName(
-  document: vscode.TextDocument,
-  position: vscode.Position,
-): string | void {
-  const textLine = document.lineAt(position.line);
-  const functionRegex = /fn\s*(?<name>[\dA-z]+)?\s*\(/;
-  const match = textLine.text.match(functionRegex);
-  return match?.groups?.name;
 }


### PR DESCRIPTION
Now there's an option for using the autometrics explorer as the default target for graphs. This demo is focused on the rust integration. 

https://github.com/autometrics-dev/vscode-autometrics/assets/473804/aab0061f-4328-4139-b597-73a0547f3f5c

The treeview can also link to the explorer, however not for the `metrics` graphs, the explorer UI doesn't support 
https://github.com/autometrics-dev/vscode-autometrics/assets/473804/b8f26ed4-4cd6-4adb-9667-114a7aa3226a

Resolves https://github.com/autometrics-dev/vscode-autometrics/issues/54