### PR TITLE
Support renamed metrics (and fix build_info queries)

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -1,7 +1,7 @@
 const COUNTER_NAME = "function_calls(_count)?(_total)?";
 
 const ADD_BUILD_INFO_LABELS =
-  "* on (instance, job) group_left(version, commit) last_over_time(build_info[1s])";
+  "* on (instance, job) group_left(version, commit) (last_over_time(build_info[1s]) or on (instance, job) up)";
 
 export function getRequestRate(
   functionName: string,
@@ -133,7 +133,7 @@ export function generateLatencyQuery(
       )
       # Attach the "version" and "commit" labels from the "build_info" metric 
       * on (instance, job) group_left(version, commit) (
-        last_over_time(build_info[1s])
+        last_over_time(build_info[1s]) or on (instance, job) up
       )
     )
   ),
@@ -155,8 +155,8 @@ export function generateLatencyQuery(
       )
       # Attach the "version" and "commit" labels from the "build_info" metric 
       * on (instance, job) group_left(version, commit) (
-        last_over_time(build_info[1s])
-      )
+        last_over_time(build_info[1s]) or on (instance, job) up
+      ) 
     )
   ),
   # Add the label {percentile_latency="95"} to the time series

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -15,13 +15,6 @@ export function getCalledByRequestRate(functionName: string) {
 ${getSumQuery(COUNTER_NAME, { caller: functionName })}`;
 }
 
-export function getErrorRatio(functionName: string) {
-  return `# Percentage of calls to the \`${functionName}\` function that return errors, averaged over 5 minute windows
-
-${getSumQuery(COUNTER_NAME, { function: functionName, result: "error" })} /
-${getSumQuery(COUNTER_NAME, { function: functionName })}`;
-}
-
 export function getCalledByErrorRatio(functionName: string) {
   return `# Percentage of calls to functions called by \`${functionName}\` that return errors, averaged over 5 minute windows
 

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -1,8 +1,5 @@
 const COUNTER_NAME = "function_calls(_count)?(_total)?";
 
-const ADD_BUILD_INFO_LABELS =
-  "* on (instance, job) group_left(version, commit) (last_over_time(build_info[1s]) or on (instance, job) up)";
-
 export function getRequestRate(
   functionName: string,
   labels: Record<string, string> = {},
@@ -30,15 +27,6 @@ export function getCalledByErrorRatio(functionName: string) {
 
 ${getSumQuery(COUNTER_NAME, { caller: functionName, result: "error" })} /
 ${getSumQuery(COUNTER_NAME, { caller: functionName })}`;
-}
-
-export function getLatency(functionName: string) {
-  const latency = `sum by (le, function, module, commit, version) (rate({__name__=~"function_calls_duration(_seconds)?_bucket",function="${functionName}"}[5m]) ${ADD_BUILD_INFO_LABELS})`;
-
-  return `# 95th and 99th percentile latencies for the \`${functionName}\` function
-
-label_replace(histogram_quantile(0.99, ${latency}), "percentile_latency", "99", "", "") or
-label_replace(histogram_quantile(0.95, ${latency}), "percentile_latency", "95", "", "")`;
 }
 
 export function getSumQuery(

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -33,7 +33,7 @@ ${getSumQuery(COUNTER_NAME, { caller: functionName })}`;
 }
 
 export function getLatency(functionName: string) {
-  const latency = `sum by (le, function, module, commit, version) (rate({__name__="function_calls_duration(_seconds)?_bucket",function="${functionName}"}[5m]) ${ADD_BUILD_INFO_LABELS})`;
+  const latency = `sum by (le, function, module, commit, version) (rate({__name__=~"function_calls_duration(_seconds)?_bucket",function="${functionName}"}[5m]) ${ADD_BUILD_INFO_LABELS})`;
 
   return `# 95th and 99th percentile latencies for the \`${functionName}\` function
 

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -137,7 +137,7 @@ export function generateLatencyQuery(
       # Attach the "version" and "commit" labels from the "build_info" metric 
       * on (instance, job) group_left(version, commit) (
         last_over_time(build_info[1s]) or on (instance, job) up
-      ) 
+      )
     )
   ),
   # Add the label {percentile_latency="95"} to the time series


### PR DESCRIPTION
I hit an issue while testing the 0.5.0 prerelease. I thought it might have to do with the updates in metric names, so I changed those. 

Turns out the issue was with the build_info query. So, I patched that.

Everything's working now for me locally

Fixes #55 